### PR TITLE
Update Preview in Marked.applescript

### DIFF
--- a/Preview in Marked.applescript
+++ b/Preview in Marked.applescript
@@ -4,7 +4,7 @@ tell application "BBEdit"
 	set filename to file of front window
 end tell
 
-tell application "Marked"
+tell application "Marked 2"
 	activate
 	open filename
 end tell


### PR DESCRIPTION
Correct application name to Marked 2 so user won't have to select the correct app when running script for first time.
